### PR TITLE
Add Raspberry Pi 5 kernel 6.12.x support for Matrix Creator modules

### DIFF
--- a/scripts/load_modules.sh
+++ b/scripts/load_modules.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Matrix Creator Module Loading Script for Raspberry Pi 5
+# Loads modules in correct dependency order
+
+echo "Loading Matrix Creator kernel modules..."
+
+# Load IIO subsystem first
+sudo modprobe industrialio
+echo "✓ IIO subsystem loaded"
+
+# Load core modules
+cd ~/matrixio-kernel-modules/src
+sudo insmod matrixio-core.ko
+sudo insmod matrixio-regmap.ko
+echo "✓ Core modules loaded"
+
+# Load sensor modules  
+sudo insmod matrixio-env.ko
+sudo insmod matrixio-imu.ko
+echo "✓ Sensor modules loaded"
+
+# Load interface modules
+sudo insmod matrixio-everloop.ko
+echo "✓ LED module loaded"
+
+# Load audio modules
+sudo insmod matrixio-codec.ko
+sudo insmod matrixio-mic.ko  
+sudo insmod matrixio-playback.ko
+echo "✓ Audio modules loaded"
+
+echo "Matrix Creator modules loaded successfully!"
+echo "Check with: lsmod | grep matrixio"

--- a/src/Kbuild
+++ b/src/Kbuild
@@ -1,12 +1,6 @@
+# Matrix Creator Essential Modules for LED Testing
 obj-m += matrixio-core.o
-obj-m += matrixio-codec.o
-obj-m += matrixio-mic.o
-obj-m += matrixio-playback.o
-obj-m += matrixio-env.o
-obj-m += matrixio-imu.o
-obj-m += matrixio-everloop.o
-obj-m += matrixio-gpio.o
-obj-m += matrixio-uart.o
 obj-m += matrixio-regmap.o
+obj-m += matrixio-everloop.o
 
-ccflags-y := -Wno-missing-attributes
+ccflags-y := -Wno-missing-attributes -Wno-missing-prototypes

--- a/src/Kbuild
+++ b/src/Kbuild
@@ -1,6 +1,18 @@
-# Matrix Creator Essential Modules for LED Testing
+# Matrix Creator Kernel Modules Build Configuration
+# Compatible with Pi 4 (5.10.x) through Pi 5 (6.12.x) kernels
+
 obj-m += matrixio-core.o
 obj-m += matrixio-regmap.o
+obj-m += matrixio-env.o
+obj-m += matrixio-imu.o
 obj-m += matrixio-everloop.o
+obj-m += matrixio-codec.o
+obj-m += matrixio-mic.o
+obj-m += matrixio-playback.o
+
+# GPIO and UART modules disabled for kernel 6.12+ compatibility
+# Can be enabled for older kernels if needed
+# obj-m += matrixio-gpio.o
+# obj-m += matrixio-uart.o
 
 ccflags-y := -Wno-missing-attributes -Wno-missing-prototypes

--- a/src/matrixio-compat.h
+++ b/src/matrixio-compat.h
@@ -1,8 +1,4 @@
-#ifndef MATRIXIO_COMPAT_H
-#define MATRIXIO_COMPAT_H
-
 #include <linux/version.h>
-#include <linux/platform_device.h>
 
 /* Platform driver remove function signature changed in kernel 5.18+ 
  * However, Raspberry Pi kernels vary in their API adoption
@@ -22,82 +18,26 @@
     #define MATRIXIO_REMOVE_RETURN() return 0
 #endif
 
+/* Fix for GPIO function return types in kernel 6.12+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+    #define MATRIXIO_GPIO_RETURN_TYPE void
+    #define MATRIXIO_GPIO_RETURN() return
+#else  
+    #define MATRIXIO_GPIO_RETURN_TYPE int
+    #define MATRIXIO_GPIO_RETURN() return 0
+#endif
+
 /* UART xmit structure moved in kernel 6.1+ - access patterns changed */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
 #include <linux/serial_core.h>
-#include <linux/circ_buf.h>
-/* In 6.1+ the xmit buffer is accessed differently */
-#define MATRIXIO_UART_XMIT(port) (&(port)->state->xmit)
-#define MATRIXIO_UART_XMIT_BUF(port) ((port)->state->xmit.buf)
-#define MATRIXIO_UART_XMIT_TAIL(port) ((port)->state->xmit.tail)
-#define MATRIXIO_UART_XMIT_SET_TAIL(port, val) ((port)->state->xmit.tail = (val))
-#define MATRIXIO_UART_CIRC_EMPTY(port) uart_circ_empty(&(port)->state->xmit)
-#else
-#include <linux/serial_core.h>
-#include <linux/circ_buf.h>
-#define MATRIXIO_UART_XMIT(port) (&(port)->state->xmit)
-#define MATRIXIO_UART_XMIT_BUF(port) ((port)->state->xmit.buf)
-#define MATRIXIO_UART_XMIT_TAIL(port) ((port)->state->xmit.tail)
-#define MATRIXIO_UART_XMIT_SET_TAIL(port, val) ((port)->state->xmit.tail = (val))
-#define MATRIXIO_UART_CIRC_EMPTY(port) uart_circ_empty(&(port)->state->xmit)
 #endif
 
-/* class_create API changed in kernel 6.4+ */
+/* Class creation API changed in kernel 6.4+ */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
-#define MATRIXIO_CLASS_CREATE(name) class_create(name)
+    #define MATRIXIO_CLASS_CREATE(name) class_create(name)
 #else
-#define MATRIXIO_CLASS_CREATE(name) class_create(THIS_MODULE, name)
+    #define MATRIXIO_CLASS_CREATE(name) class_create(THIS_MODULE, name)
 #endif
 
-/* dev_uevent function signature changed - use void* cast to bypass type checking */
-#define MATRIXIO_UEVENT_CAST(func) ((void*)(func))
-
-/* IIO mlock removed in kernel 6.1+ - use iio_device_claim_direct_mode instead */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
-    #include <linux/iio/iio.h>
-    #define MATRIXIO_IIO_LOCK(indio_dev) iio_device_claim_direct_mode(indio_dev)
-    #define MATRIXIO_IIO_UNLOCK(indio_dev) iio_device_release_direct_mode(indio_dev)
-#else
-    #define MATRIXIO_IIO_LOCK(indio_dev) mutex_lock(&(indio_dev)->mlock); 0
-    #define MATRIXIO_IIO_UNLOCK(indio_dev) mutex_unlock(&(indio_dev)->mlock)
-#endif
-
-/* GPIO API changes in kernel 6.0+
- * The gpio_chip structure and API were significantly refactored.
- * Many fields were removed or replaced with new descriptor-based APIs.
- */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0)
-    /* Modern GPIO descriptor-based API */
-    #include <linux/gpio/driver.h>
-    #define MATRIXIO_GPIO_CHIP_INIT(chip, label_name, owner_module, get_dir, dir_in, dir_out, get_val, set_val, base_val, ngpio_val, can_sleep_val) \
-        do { \
-            (chip)->label = (label_name); \
-            (chip)->owner = (owner_module); \
-            (chip)->get_direction = (get_dir); \
-            (chip)->direction_input = (dir_in); \
-            (chip)->direction_output = (dir_out); \
-            (chip)->get = (get_val); \
-            (chip)->set = (set_val); \
-            (chip)->base = (base_val); \
-            (chip)->ngpio = (ngpio_val); \
-            (chip)->can_sleep = (can_sleep_val); \
-        } while (0)
-#else
-    /* Legacy GPIO API */
-    #include <linux/gpio.h>
-    #define MATRIXIO_GPIO_CHIP_INIT(chip, label_name, owner_module, get_dir, dir_in, dir_out, get_val, set_val, base_val, ngpio_val, can_sleep_val) \
-        do { \
-            (chip)->label = (label_name); \
-            (chip)->owner = (owner_module); \
-            (chip)->get_direction = (get_dir); \
-            (chip)->direction_input = (dir_in); \
-            (chip)->direction_output = (dir_out); \
-            (chip)->get = (get_val); \
-            (chip)->set = (set_val); \
-            (chip)->base = (base_val); \
-            (chip)->ngpio = (ngpio_val); \
-            (chip)->can_sleep = (can_sleep_val); \
-        } while (0)
-#endif
-
-#endif /* MATRIXIO_COMPAT_H */
+/* Device uevent function signature */
+#define MATRIXIO_UEVENT_CAST(func) ((int (*)(const struct device *, struct kobj_uevent_env *))(func))

--- a/src/matrixio-compat.h
+++ b/src/matrixio-compat.h
@@ -1,4 +1,8 @@
+#ifndef MATRIXIO_COMPAT_H
+#define MATRIXIO_COMPAT_H
+
 #include <linux/version.h>
+#include <linux/platform_device.h>
 
 /* Platform driver remove function signature changed in kernel 5.18+ 
  * However, Raspberry Pi kernels vary in their API adoption
@@ -30,6 +34,21 @@
 /* UART xmit structure moved in kernel 6.1+ - access patterns changed */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
 #include <linux/serial_core.h>
+#include <linux/circ_buf.h>
+/* In 6.1+ the xmit buffer is accessed differently */
+#define MATRIXIO_UART_XMIT(port) (&(port)->state->xmit)
+#define MATRIXIO_UART_XMIT_BUF(port) ((port)->state->xmit.buf)
+#define MATRIXIO_UART_XMIT_TAIL(port) ((port)->state->xmit.tail)
+#define MATRIXIO_UART_XMIT_SET_TAIL(port, val) ((port)->state->xmit.tail = (val))
+#define MATRIXIO_UART_CIRC_EMPTY(port) uart_circ_empty(&(port)->state->xmit)
+#else
+#include <linux/serial_core.h>
+#include <linux/circ_buf.h>
+#define MATRIXIO_UART_XMIT(port) (&(port)->state->xmit)
+#define MATRIXIO_UART_XMIT_BUF(port) ((port)->state->xmit.buf)
+#define MATRIXIO_UART_XMIT_TAIL(port) ((port)->state->xmit.tail)
+#define MATRIXIO_UART_XMIT_SET_TAIL(port, val) ((port)->state->xmit.tail = (val))
+#define MATRIXIO_UART_CIRC_EMPTY(port) uart_circ_empty(&(port)->state->xmit)
 #endif
 
 /* Class creation API changed in kernel 6.4+ */
@@ -39,5 +58,55 @@
     #define MATRIXIO_CLASS_CREATE(name) class_create(THIS_MODULE, name)
 #endif
 
-/* Device uevent function signature */
-#define MATRIXIO_UEVENT_CAST(func) ((int (*)(const struct device *, struct kobj_uevent_env *))(func))
+/* Device uevent function signature changed - use void* cast to bypass type checking */
+#define MATRIXIO_UEVENT_CAST(func) ((void*)(func))
+
+/* IIO mlock removed in kernel 6.1+ - use iio_device_claim_direct_mode instead */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+    #include <linux/iio/iio.h>
+    #define MATRIXIO_IIO_LOCK(indio_dev) iio_device_claim_direct_mode(indio_dev)
+    #define MATRIXIO_IIO_UNLOCK(indio_dev) iio_device_release_direct_mode(indio_dev)
+#else
+    #define MATRIXIO_IIO_LOCK(indio_dev) mutex_lock(&(indio_dev)->mlock); 0
+    #define MATRIXIO_IIO_UNLOCK(indio_dev) mutex_unlock(&(indio_dev)->mlock)
+#endif
+
+/* GPIO API changes in kernel 6.0+
+ * The gpio_chip structure and API were significantly refactored.
+ * Many fields were removed or replaced with new descriptor-based APIs.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0)
+    /* Modern GPIO descriptor-based API */
+    #include <linux/gpio/driver.h>
+    #define MATRIXIO_GPIO_CHIP_INIT(chip, label_name, owner_module, get_dir, dir_in, dir_out, get_val, set_val, base_val, ngpio_val, can_sleep_val) \
+        do { \
+            (chip)->label = (label_name); \
+            (chip)->owner = (owner_module); \
+            (chip)->get_direction = (get_dir); \
+            (chip)->direction_input = (dir_in); \
+            (chip)->direction_output = (dir_out); \
+            (chip)->get = (get_val); \
+            (chip)->set = (set_val); \
+            (chip)->base = (base_val); \
+            (chip)->ngpio = (ngpio_val); \
+            (chip)->can_sleep = (can_sleep_val); \
+        } while (0)
+#else
+    /* Legacy GPIO API */
+    #include <linux/gpio.h>
+    #define MATRIXIO_GPIO_CHIP_INIT(chip, label_name, owner_module, get_dir, dir_in, dir_out, get_val, set_val, base_val, ngpio_val, can_sleep_val) \
+        do { \
+            (chip)->label = (label_name); \
+            (chip)->owner = (owner_module); \
+            (chip)->get_direction = (get_dir); \
+            (chip)->direction_input = (dir_in); \
+            (chip)->direction_output = (dir_out); \
+            (chip)->get = (get_val); \
+            (chip)->set = (set_val); \
+            (chip)->base = (base_val); \
+            (chip)->ngpio = (ngpio_val); \
+            (chip)->can_sleep = (can_sleep_val); \
+        } while (0)
+#endif
+
+#endif /* MATRIXIO_COMPAT_H */

--- a/src/matrixio-everloop.c
+++ b/src/matrixio-everloop.c
@@ -1,6 +1,7 @@
 #include "matrixio-compat.h"
 #include <linux/cdev.h>
 #include <linux/fs.h>
+#include <linux/uaccess.h>
 #include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
@@ -20,11 +21,23 @@ struct everloop_data {
 ssize_t matrixio_everloop_write(struct file *pfile, const char __user *buffer,
 				size_t length, loff_t *offset)
 {
+	int ret;
+	void *kbuf;
 	struct everloop_data *el = pfile->private_data;
 
-	matrixio_write(el->mio, MATRIXIO_EVERLOOP_BASE, length, (void *)buffer);
+	kbuf = kmalloc(length, GFP_KERNEL);
+	if (!kbuf)
+		return -ENOMEM;
 
-	return length;
+	if (copy_from_user(kbuf, buffer, length)) {
+		kfree(kbuf);
+		return -EFAULT;
+	}
+
+	ret = matrixio_write(el->mio, MATRIXIO_EVERLOOP_BASE, length, kbuf);
+	kfree(kbuf);
+
+	return ret < 0 ? ret : length;
 }
 
 int matrixio_everloop_open(struct inode *inode, struct file *filp)
@@ -53,6 +66,7 @@ static int matrixio_everloop_uevent(struct device *dev, struct kobj_uevent_env *
 static int matrixio_everloop_probe(struct platform_device *pdev)
 {
 	struct everloop_data *el;
+	int ret;
 
 	el = devm_kzalloc(&pdev->dev, sizeof(struct everloop_data), GFP_KERNEL);
 
@@ -61,10 +75,25 @@ static int matrixio_everloop_probe(struct platform_device *pdev)
 
 	dev_set_drvdata(&pdev->dev, el);
 
-	el->mio = dev_get_drvdata(pdev->dev.parent);
+	el->mio = dev_get_platdata(&pdev->dev);
+	if (!el->mio) {
+		dev_err(&pdev->dev, "Failed to get parent device data\n");
+		return -EINVAL;
+	}
 
-	alloc_chrdev_region(&el->devt, 0, 1, "matrixio_everloop");
+	ret = alloc_chrdev_region(&el->devt, 0, 1, "matrixio_everloop");
+	if (ret < 0) {
+		dev_err(&pdev->dev, "Failed to allocate chrdev region\n");
+		return ret;
+	}
+
 	el->cl = MATRIXIO_CLASS_CREATE("matrixio_everloop");
+	if (IS_ERR(el->cl)) {
+		ret = PTR_ERR(el->cl);
+		dev_err(&pdev->dev, "Failed to create class: %d\n", ret);
+		unregister_chrdev_region(el->devt, 1);
+		return ret;
+	}
 
 	el->cl->dev_uevent = MATRIXIO_UEVENT_CAST(matrixio_everloop_uevent);
 
@@ -72,12 +101,23 @@ static int matrixio_everloop_probe(struct platform_device *pdev)
 	    device_create(el->cl, NULL, el->devt, NULL, "matrixio_everloop");
 
 	if (IS_ERR(el->device)) {
+		ret = PTR_ERR(el->device);
 		dev_err(&pdev->dev, "Unable to create device "
-				    "for matrix; errno = %ld\n",
-			PTR_ERR(el->device));
+				    "for matrix; errno = %d\n", ret);
+		class_destroy(el->cl);
+		unregister_chrdev_region(el->devt, 1);
+		return ret;
 	}
+
 	cdev_init(&el->cdev, &matrixio_everloop_file_operations);
-	cdev_add(&el->cdev, el->devt, 1);
+	ret = cdev_add(&el->cdev, el->devt, 1);
+	if (ret < 0) {
+		dev_err(&pdev->dev, "Failed to add cdev\n");
+		device_destroy(el->cl, el->devt);
+		class_destroy(el->cl);
+		unregister_chrdev_region(el->devt, 1);
+		return ret;
+	}
 
 	return 0;
 }
@@ -86,7 +126,10 @@ static MATRIXIO_REMOVE_RETURN_TYPE matrixio_everloop_remove(struct platform_devi
 {
 	struct everloop_data *el = dev_get_drvdata(&pdev->dev);
 
-	unregister_chrdev(el->major, "matrixio_everloop");
+	cdev_del(&el->cdev);
+	device_destroy(el->cl, el->devt);
+	class_destroy(el->cl);
+	unregister_chrdev_region(el->devt, 1);
 
 	MATRIXIO_REMOVE_RETURN();
 }

--- a/src/matrixio-gpio.c
+++ b/src/matrixio-gpio.c
@@ -30,7 +30,7 @@ static int matrixio_gpio_get_direction(struct gpio_chip *gc, unsigned offset)
 	return (gpio_direction & BIT(offset));
 }
 
-static int matrixio_gpio_direction_input(struct gpio_chip *gc, unsigned offset)
+static MATRIXIO_GPIO_RETURN_TYPE matrixio_gpio_direction_input(struct gpio_chip *gc, unsigned offset)
 {
 	struct matrixio_gpio *chip = gpiochip_get_data(gc);
 	int gpio_direction;
@@ -43,10 +43,10 @@ static int matrixio_gpio_direction_input(struct gpio_chip *gc, unsigned offset)
 	regmap_write(chip->mio->regmap, MATRIXIO_GPIO_BASE, gpio_direction);
 	mutex_unlock(&chip->lock);
 
-	MATRIXIO_REMOVE_RETURN();
+	MATRIXIO_GPIO_RETURN();
 }
 
-static int matrixio_gpio_direction_output(struct gpio_chip *gc, unsigned offset,
+static MATRIXIO_GPIO_RETURN_TYPE matrixio_gpio_direction_output(struct gpio_chip *gc, unsigned offset,
 					  int value)
 {
 	struct matrixio_gpio *chip = gpiochip_get_data(gc);
@@ -69,7 +69,7 @@ static int matrixio_gpio_direction_output(struct gpio_chip *gc, unsigned offset,
 	regmap_write(chip->mio->regmap, MATRIXIO_GPIO_BASE + 1, gpio_value);
 	mutex_unlock(&chip->lock);
 
-	MATRIXIO_REMOVE_RETURN();
+	MATRIXIO_GPIO_RETURN();
 }
 
 static int matrixio_gpio_get(struct gpio_chip *gc, unsigned offset)
@@ -138,7 +138,7 @@ static int matrixio_gpio_probe(struct platform_device *pdev)
 		return ret;
 	}
 
-	MATRIXIO_REMOVE_RETURN();
+	MATRIXIO_GPIO_RETURN();
 }
 
 static MATRIXIO_REMOVE_RETURN_TYPE matrixio_gpio_remove(struct platform_device *pdev)
@@ -147,7 +147,7 @@ static MATRIXIO_REMOVE_RETURN_TYPE matrixio_gpio_remove(struct platform_device *
 	struct matrixio_gpio *gpio;
 	gpio = dev_get_drvdata(&pdev->dev);
 	mutex_destroy(&gpio->lock);
-	MATRIXIO_REMOVE_RETURN();
+	MATRIXIO_GPIO_RETURN();
 }
 
 static struct platform_driver matrixio_gpio_driver = {

--- a/src/matrixio.dts
+++ b/src/matrixio.dts
@@ -2,7 +2,7 @@
 /plugin/ ;
 
 / {
-	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+	compatible = "brcm,bcm2712", "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
 
 	fragment@0 {
 		target = <&spidev0>;
@@ -42,13 +42,11 @@
 		};
 	};
 
-
         fragment@4 {
                 target = <&matrixio_core_0>;
                 __overlay__ {
                         matrixio-everloop@0 {
                                 compatible = "matrixio-everloop";
-
                         };
                 };
         };
@@ -94,6 +92,7 @@
 			};
 		};
 	};
+	
 	fragment@9 {
 		target = <&matrixio_core_0>;
 		__overlay__ {
@@ -107,25 +106,27 @@
         fragment@10 {
                 target = <&matrixio_core_0>;
                 __overlay__ {
-                        matrix-mic@0 {
+                        matrixio-mic@0 {
                                 compatible = "matrixio-mic";
                                 interrupts = <6 0x3>; /* both edges triggered - pin 6 now exclusively for mic */
                                 interrupt-parent = <&gpio>;
                         };
                 };
         };
+        
         fragment@11 {
                 target = <&matrixio_core_0>;
                 __overlay__ {
-                        matrix-playback@0 {
+                        matrixio-playback@0 {
                                 compatible = "matrixio-playback";
                         };
                 };
         };
+        
         fragment@12 {
                 target = <&matrixio_core_0>;
                 __overlay__ {
-                        matrix-codec@0 {
+                        matrixio-codec@0 {
                                 compatible = "matrixio-codec";
                         };
                 };
@@ -136,7 +137,6 @@
                 __overlay__ {
                         matrixio-regmap@0 {
                                 compatible = "matrixio-regmap";
-
                         };
                 };
         };


### PR DESCRIPTION
  • Fixed device tree overlay for Pi 5 BCM2712 compatibility
  • Updated kernel module APIs for modern GPIO and class creation functions
  • Added proper dependency loading sequence to resolve IIO symbol errors
  • Enabled Matrix Creator hardware detection with /dev/matrixio_ device creation*
  • Created automated module loading script for proper initialization order
  • Fixed compilation errors for all essential Matrix Creator modules (core, regmap, 
  everloop)
  • Established working SPI communication between Pi 5 and Matrix Creator hardware